### PR TITLE
Operations page

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -80,8 +80,16 @@ body {
   margin-bottom: 0.5rem;
 }
 
+.margin {
+  margin: 1.5rem 1rem 1rem 1rem;
+}
+
 .margin-y {
   margin: 1rem 0 1rem 0;
+}
+
+.margin-x {
+  margin: 0 1rem 0 1rem;
 }
 
 .margin-b {

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -207,3 +207,27 @@ body {
 .gap {
   gap: 1rem;
 }
+
+.money-amount {
+  background-color: #fff;
+  padding: 1rem;
+  border-bottom: 1px groove rgba(28, 110, 164, 0.11);
+}
+
+.justify-content-evenly {
+  justify-content: space-between;
+}
+
+.padding {
+  padding: 1rem;
+}
+
+.position-relative {
+  position: relative;
+}
+
+.position-absolute {
+  position: absolute;
+  top: 0;
+  left: 2%;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,8 @@
 class ApplicationController < ActionController::Base
+  rescue_from 'CanCan::AccessDenied' do |_exception|
+    redirect_to root_path, alert: 'You are not authorized to access that page.'
+  end
+
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   def after_sign_in_path_for(_resource)

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -13,7 +13,7 @@ class GroupsController < ApplicationController
     @group = Group.new(group_params)
 
     if @group.save
-      redirect_to root_path, notice: 'Successfully created a group.'
+      redirect_to groups_path, notice: 'Successfully created a group.'
     else
       flash[:alert] = 'Failed to create a group.'
       render :new

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,3 +1,7 @@
 class HomeController < ApplicationController
-  def index; end
+  def index
+    if current_user
+      redirect_to groups_path
+    end
+  end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,5 @@
 class HomeController < ApplicationController
   def index
-    if current_user
-      redirect_to groups_path
-    end
+    redirect_to groups_path if current_user
   end
 end

--- a/app/controllers/operations_controller.rb
+++ b/app/controllers/operations_controller.rb
@@ -1,7 +1,10 @@
 class OperationsController < ApplicationController
   load_and_authorize_resource
 
-  def index; end
+  def index
+    @group = Group.find_by(id: params[:group_id])
+    @operations = helpers.find_operations
+  end
 
   def new
     @operation = Operation.new

--- a/app/controllers/operations_controller.rb
+++ b/app/controllers/operations_controller.rb
@@ -16,7 +16,7 @@ class OperationsController < ApplicationController
     helpers.create_groups_operations(@operation, params[:group][:group_id])
 
     if @operation.save
-      redirect_to root_path, notice: 'Successfully created an operation.'
+      redirect_to groups_path, notice: 'Successfully created an operation.'
     else
       flash[:alert] = 'Failed to create an operation.'
       render :new

--- a/app/helpers/operations_helper.rb
+++ b/app/helpers/operations_helper.rb
@@ -1,4 +1,13 @@
 module OperationsHelper
+  def find_operations
+    operations = []
+    groups_operations = GroupsOperation.where(group_id: params[:group_id]).order(created_at: :desc)
+    groups_operations.each do |group_operation|
+      operations << Operation.find_by(id: group_operation.operation_id)
+    end
+    operations
+  end
+
   def create_groups_operations(operation, array)
     i = 1
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -2,8 +2,6 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
-    user ||= User.new
-
     return unless user.present?
 
     can :manage, Group, author_id: user.id

--- a/app/models/groups_operation.rb
+++ b/app/models/groups_operation.rb
@@ -1,0 +1,2 @@
+class GroupsOperation < ApplicationRecord
+end

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -2,6 +2,11 @@
   <h1>Groups</h1>
 </header>
 <section>
+  <% if @groups.empty? %>
+    <div class="information padding border">
+      <h3 class="text-center">No groups yet.</h3>
+    </div>
+  <% else %>
   <% @groups.each do |group| %>
     <div class="d-flex information border gap">
       <img src=<%= group.icon %> alt=<%= group.name %> class="icon">
@@ -15,6 +20,7 @@
         </small>
       </div>
     </div>
+  <% end %>
   <% end %>
   <div class="margin">
     <%= link_to "Add group", new_group_path, class: "btn" %>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -16,4 +16,8 @@
       </div>
     </div>
   <% end %>
+  <div class="margin">
+  <%= link_to "Add group", new_group_path, class: "btn" %>
+
+  </div>
 </section>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -17,7 +17,6 @@
     </div>
   <% end %>
   <div class="margin">
-  <%= link_to "Add group", new_group_path, class: "btn" %>
-
+    <%= link_to "Add group", new_group_path, class: "btn" %>
   </div>
 </section>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -10,11 +10,11 @@
 <%= form_with model: @group, data: { turbo: false }, class: "container form margin-y border-y" do |form| %>
 
   <div class="form-group">
-    <%= form.text_field :name, autofocus: true, placeholder: "Name", class: "form-control " %>
+    <%= form.text_field :name, autofocus: true, placeholder: "Name", class: "form-control", required: true %>
   </div>
 
   <div class="form-group">
-    <%= form.text_field :icon, placeholder: "Icon link", class: "form-control" %>
+    <%= form.text_field :icon, placeholder: "Icon link", class: "form-control", required: true %>
   </div>
 
   <%= form.submit "Save", class: "btn align-self-start margin-y" %>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -1,5 +1,10 @@
 <header class="header container primary-gradient-background">
-  <h1>Create Group</h1>
+  <h1 class="position-absolute">
+    <%= link_to groups_path do %>
+      <i class="bi bi-arrow-left"></i>
+    <% end %>
+  </h1>
+  <h1 class="text-center margin-y">Create Group</h1>
 </header>
 
 <%= form_with model: @group, data: { turbo: false }, class: "container form margin-y border-y" do |form| %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,8 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.2/font/bootstrap-icons.css">
+
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>

--- a/app/views/operations/index.html.erb
+++ b/app/views/operations/index.html.erb
@@ -1,6 +1,6 @@
 <header class="header container primary-gradient-background position-relative">
   <h1 class="position-absolute">
-    <%= link_to :back do %>
+    <%= link_to groups_path do %>
       <i class="bi bi-arrow-left"></i>
     <% end %>
     </h1>

--- a/app/views/operations/index.html.erb
+++ b/app/views/operations/index.html.erb
@@ -1,0 +1,28 @@
+<header class="header container primary-gradient-background position-relative">
+  <h1 class="position-absolute">
+    <%= link_to :back do %>
+      <i class="bi bi-arrow-left"></i>
+    <% end %>
+    </h1>
+  <h1 class="text-center margin-y">Operations for <%= @group.name %></h1>
+</header>
+<section>
+  <div class="money-amount">
+    <p  class="text-center">Money spent: $<%= group_amount(@group) %></p>
+  </div>
+  <% if @operations.empty? %>
+    <div class="information padding border">
+      <h3 class="text-center">No operations yet.</h3>
+    </div>
+  <% else %>
+    <% @operations.each do |operation| %>
+      <div class="information d-flex justify-content-evenly padding border">
+        <h3><%= operation.name %></h3>
+        <p>$<%= operation.amount %></p>
+      </div>
+    <% end %>
+  <% end %>
+  <div class="margin">
+    <%= link_to "Add operation", new_operation_path, class: "btn" %>
+  </div>
+</section>

--- a/app/views/operations/new.html.erb
+++ b/app/views/operations/new.html.erb
@@ -10,16 +10,16 @@
 <%= form_with model: @operation, data: { turbo: false }, class: "container form margin-y border-y" do |form| %>
 
   <div class="form-group">
-    <%= form.text_field :name, autofocus: true, placeholder: "Name", class: "form-control" %>
+    <%= form.text_field :name, autofocus: true, placeholder: "Name", class: "form-control", required: true %>
   </div>
 
   <div class="form-group">
-    <%= form.number_field :amount, placeholder: "Amount", class: "form-control" %>
+    <%= form.number_field :amount, placeholder: "Amount", class: "form-control", required: true %>
   </div>
 
   <div class="form-group">
     <%= form.label :group, class: "form-label" %>
-    <%= select("group", "group_id", Group.all.collect { |g| [ g.name, g.id ] }, { include_blank: false }, required: true, multiple: true, size: 3, class: "form-control") %>
+    <%= select("group", "group_id", Group.all.collect { |g| [ g.name, g.id ] }, { include_blank: false }, required: true, multiple: true, size: 3, class: "form-control", required: true) %>
   </div>
 
   <%= form.submit "Save", class: "btn align-self-start margin-y" %>

--- a/app/views/operations/new.html.erb
+++ b/app/views/operations/new.html.erb
@@ -1,5 +1,10 @@
 <header class="header container primary-gradient-background">
-  <h1 class="text-center">Create Operation</h1>
+  <h1 class="position-absolute">
+    <%= link_to groups_path do %>
+      <i class="bi bi-arrow-left"></i>
+    <% end %>
+    </h1>
+  <h1 class="text-center margin-y">Create Operation</h1>
 </header>
 
 <%= form_with model: @operation, data: { turbo: false }, class: "container form margin-y border-y" do |form| %>


### PR DESCRIPTION
In this pull request, I:
- Added 'add group' link in the groups index view
- Added and styled operations index view
- Added alternative text if there are no groups
- Changed the path of the back button to groups path (homepage)
- Fixed authorization (a non-logged-in user could see every page) 
- Added `required: true` to all input fields in groups and operations